### PR TITLE
Background notification should trigger event if possible

### DIFF
--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -206,10 +206,11 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
             Log.d(LOG_TAG, "create notification");
 
             createNotification(context, extras);
-        } else {
-            Log.d(LOG_TAG, "send notification event");
-            PushPlugin.sendExtras(extras);
         }
+        //Should always send notification event
+        Log.d(LOG_TAG, "send notification event");
+        PushPlugin.sendExtras(extras);
+        
     }
 
     public void createNotification(Context context, Bundle extras) {


### PR DESCRIPTION
Notification event should always be sent, if possible. This removes the problem where notification gets to the desk, but event handler is never called.
